### PR TITLE
Add support for crate renaming.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fix-hidden-lifetime-bug"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "automod",
  "fix-hidden-lifetime-bug-proc_macros",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "fix-hidden-lifetime-bug-proc_macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bat",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fix-hidden-lifetime-bug"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -14,7 +14,7 @@ keywords = ["impl", "lifetime", "bug", "hidden", "bound"]
 
 [dependencies.proc-macros]
 package = "fix-hidden-lifetime-bug-proc_macros"
-version = "0.2.4"
+version = "0.2.5"
 path = "src/proc_macros"
 optional = true
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -4,7 +4,7 @@ proc-macro = true
 
 [package]
 name = "fix-hidden-lifetime-bug-proc_macros"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -17,10 +17,13 @@ readme = "../../README.md"
 keywords = ["impl", "lifetime", "bug", "hidden", "bound"]
 
 [dependencies]
-bat = { optional = true, version = "0.15.4" }
-proc-macro2 = "1.0.0"
-quote = "1.0.0"
-syn = { version = "1.0.7", features = ["full", "visit-mut"] }
+proc-macro2.version = "1.0.0"
+quote.version = "1.0.0"
+syn.version = "1.0.7"
+syn.features = ["full", "visit-mut"]
+
+bat.optional = true
+bat.version = "0.15.4"
 
 [features]
 default = []

--- a/src/proc_macros/manually_unsugar_async.rs
+++ b/src/proc_macros/manually_unsugar_async.rs
@@ -3,6 +3,7 @@ use super::*;
 /// Transform an `async fn` into an equivalent `fn … -> impl Future` signature.
 pub(in crate)
 fn manually_unsugar_async (
+    krate: &'_ Path,
     mut fun: ImplItemMethod,
 ) -> ImplItemMethod
 {
@@ -65,10 +66,9 @@ fn manually_unsugar_async (
         | ReturnType::Default => parse_quote!( () ),
     };
     fun.sig.output = parse_quote!(
-        ->
-        impl
+        -> impl
             #minimum_lifetime +
-            ::fix_hidden_lifetime_bug::core::future::Future<
+            #krate::core::future::Future<
                 Output = #Ret,
             >
     );

--- a/src/proc_macros/params.rs
+++ b/src/proc_macros/params.rs
@@ -4,17 +4,21 @@ mod kw {
     ::syn::custom_keyword!(showme);
 }
 
+#[derive(Default)]
 pub(in crate)
 struct Params {
     pub(in crate)
     showme: Option<kw::showme>,
+
+    pub(in crate)
+    krate: Option<Path>,
 }
 
 impl Parse for Params {
     fn parse (input: ParseStream<'_>)
       -> Result<Params>
     {
-        let mut showme = None::<kw::showme>;
+        let mut ret = Params::default();
         while input.is_empty().not() {
             let lookahead = input.lookahead1();
             match () {
@@ -22,7 +26,15 @@ impl Parse for Params {
                     if cfg!(not(feature = "showme")) {
                         return Err(input.error("Missing `showme` Cargo feature."));
                     }
-                    let prev = showme.replace(input.parse().unwrap());
+                    let prev = ret.showme.replace(input.parse().unwrap());
+                    if prev.is_some() {
+                        return Err(input.error("Duplicate parameter"));
+                    }
+                },
+                | _case if lookahead.peek(Token![crate]) => {
+                    let _: Token![crate] = input.parse().unwrap();
+                    let _: Token![=] = input.parse()?;
+                    let prev = ret.krate.replace(input.parse()?);
                     if prev.is_some() {
                         return Err(input.error("Duplicate parameter"));
                     }
@@ -31,8 +43,6 @@ impl Parse for Params {
             }
             let _: Option<Token![,]> = input.parse()?;
         }
-        Ok(Params {
-            showme,
-        })
+        Ok(ret)
     }
 }

--- a/tests/renamed.rs
+++ b/tests/renamed.rs
@@ -1,0 +1,18 @@
+/// Make `::fix_hidden_lifetime_bug` not work as expected.
+extern crate core as fix_hidden_lifetime_bug;
+
+/// But luckily, we can refer to that crate from another path:
+/// `crate::module::fix_hidden_lifetime_bug`.
+mod module {
+    pub
+    extern crate fix_hidden_lifetime_bug;
+}
+
+// It's obviously a mouthful, but it's just there to be friendly to
+// other macros.
+#[module::fix_hidden_lifetime_bug::fix_hidden_lifetime_bug(
+    crate = crate::module::fix_hidden_lifetime_bug,
+)]
+async
+fn foo (_: &(), _: &())
+{}


### PR DESCRIPTION
This can be useful when another macro crate wants to export a macro that uses this crate under the hood: the currently hard-coded `::fix_hidden_lifetime_bug` paths prevent that pattern from working.

Solution: allow the attribute to take an optional `crate = <some path>` override.