### PR TITLE
Include license files in fix-hidden-lifetime-bug-proc_macros crate

### DIFF
--- a/src/proc_macros/LICENSE-APACHE
+++ b/src/proc_macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/src/proc_macros/LICENSE-MIT
+++ b/src/proc_macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/src/proc_macros/LICENSE-ZLIB
+++ b/src/proc_macros/LICENSE-ZLIB
@@ -1,0 +1,1 @@
+../../LICENSE-ZLIB


### PR DESCRIPTION
Hi, this symlinks the license files so they're included in the `fix-hidden-lifetime-bug-proc_macros` crate (like they are with `fix-hidden-lifetime-bug`).

```sh
cd src/proc_macros
ln -s ../../LICENSE-* .
```